### PR TITLE
Fix exception when prevToken is -1

### DIFF
--- a/AnitomySharp/ParserHelper.cs
+++ b/AnitomySharp/ParserHelper.cs
@@ -283,6 +283,7 @@ namespace AnitomySharp
         public bool IsPrevTokenContainAnimeType(int pos)
         {
             var prevToken = Token.FindPrevToken(_parser.Tokens, pos, Token.TokenFlag.FlagNotDelimiter);
+            if (prevToken < 0) return false;
             var nextToken = Token.FindNextToken(_parser.Tokens, pos, Token.TokenFlag.FlagNotDelimiter);
             if (!IsTokenCategory(nextToken, Token.TokenCategory.Bracket)) return false;
             return KeywordManager.Contains(Element.ElementCategory.ElementAnimeType, _parser.Tokens[prevToken].Content);
@@ -295,6 +296,7 @@ namespace AnitomySharp
         public bool IsPrevTokenContainAnimeTypeInPeekEntries(int pos)
         {
             var prevToken = Token.FindPrevToken(_parser.Tokens, pos, Token.TokenFlag.FlagNotDelimiter);
+            if (prevToken  < 0) return false;
             var nextToken = Token.FindNextToken(_parser.Tokens, pos, Token.TokenFlag.FlagNotDelimiter);
             if (!IsTokenCategory(nextToken, Token.TokenCategory.Bracket)) return false;
             return KeywordManager.ContainsInPeekEntries(Element.ElementCategory.ElementAnimeType, _parser.Tokens[prevToken].Content);

--- a/AnitomySharpTests/test-cases.json
+++ b/AnitomySharpTests/test-cases.json
@@ -3283,5 +3283,14 @@
       ],
       "ElementVideoResolution": "720p"
     }
+  },
+  {
+    "file_name": "S03E09-Christmas [E5A9A7C6].mkv",
+    "results": {
+      "ElementAnimeTitle": "S03E09-Christmas",
+      "ElementFileChecksum": "E5A9A7C6",
+      "ElementFileExtension": "mkv",
+      "ElementFileName": "S03E09-Christmas [E5A9A7C6]"
+    }
   }
 ]


### PR DESCRIPTION
Ran into this for a few of my files. Added a test case to the testdata and made a fix.

```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at AnitomySharp.ParserHelper.IsPrevTokenContainAnimeType(Int32 pos)
   at AnitomySharp.ParserNumber.SearchForSymbolWithEpisode(List`1 tokens)
   at AnitomySharp.Parser.SearchForEpisodeNumber()
   at AnitomySharp.Parser.Parse()
   at AnitomySharp.AnitomySharp.Parse(String filename, Options options)
```